### PR TITLE
Warm start, property constraints on weighted sums (#165)

### DIFF
--- a/src/configuration/GlobalConfiguration.cpp
+++ b/src/configuration/GlobalConfiguration.cpp
@@ -54,6 +54,8 @@ const bool GlobalConfiguration::PREPROCESSOR_ELIMINATE_VARIABLES = true;
 const bool GlobalConfiguration::PREPROCESSOR_PL_CONSTRAINTS_ADD_AUX_EQUATIONS = true;
 const double GlobalConfiguration::PREPROCESSOR_ALMOST_FIXED_THRESHOLD = 0.00001;
 
+const bool GlobalConfiguration::WARM_START = false;
+
 const unsigned GlobalConfiguration::PSE_ITERATIONS_BEFORE_RESET = 1000;
 const double GlobalConfiguration::PSE_GAMMA_ERROR_THRESHOLD = 0.001;
 const double GlobalConfiguration::PSE_GAMMA_UPDATE_TOLERANCE = 0.000000001;

--- a/src/configuration/GlobalConfiguration.h
+++ b/src/configuration/GlobalConfiguration.h
@@ -76,6 +76,10 @@ public:
     // threshold, the preprocessor will treat it as fixed.
     static const double PREPROCESSOR_ALMOST_FIXED_THRESHOLD;
 
+    // Try to set the initial tableau assignment to an assignment that is legal with
+    // respect to the input network.
+    static const bool WARM_START;
+
     // How often should the main loop check the current degradation?
     static const unsigned DEGRADATION_CHECKING_FREQUENCY;
 

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -22,9 +22,9 @@
 #include "InputQuery.h"
 #include "MStringf.h"
 #include "MalformedBasisException.h"
+#include "MarabouError.h"
 #include "PiecewiseLinearConstraint.h"
 #include "Preprocessor.h"
-#include "MarabouError.h"
 #include "TableauRow.h"
 #include "TimeUtils.h"
 
@@ -1059,7 +1059,7 @@ bool Engine::processInputQuery( InputQuery &inputQuery, bool preprocess )
 
         List<unsigned> initialBasis;
         List<unsigned> basicRows;
-        selectInitialVariablesForBasis( constraintMatrix, initialBasis, basicRows ); // HERE
+        selectInitialVariablesForBasis( constraintMatrix, initialBasis, basicRows );
         addAuxiliaryVariables();
         augmentInitialBasisIfNeeded( initialBasis, basicRows );
 
@@ -1069,8 +1069,11 @@ bool Engine::processInputQuery( InputQuery &inputQuery, bool preprocess )
         delete[] constraintMatrix;
         constraintMatrix = createConstraintMatrix();
 
-        initializeTableau( constraintMatrix, initialBasis );
         initializeNetworkLevelReasoning();
+        initializeTableau( constraintMatrix, initialBasis );
+
+        if ( GlobalConfiguration::WARM_START )
+            warmStart();
 
         delete[] constraintMatrix;
 
@@ -1831,6 +1834,59 @@ void Engine::resetBoundTighteners()
 {
     _constraintBoundTightener->resetBounds();
     _rowBoundTightener->resetBounds();
+}
+
+void Engine::warmStart()
+{
+    // An NLR is required for a warm start
+    if ( !_networkLevelReasoner )
+        return;
+
+    // First, choose an arbitrary assignment for the input variables
+    unsigned numInputVariables = _preprocessedQuery.getNumInputVariables();
+    unsigned numOutputVariables = _preprocessedQuery.getNumOutputVariables();
+
+    if ( numInputVariables == 0 )
+    {
+        // Trivial case: all inputs are fixed, nothing to evaluate
+        return;
+    }
+
+    double *inputAssignment = new double[numInputVariables];
+    double *outputAssignment = new double[numOutputVariables];
+
+    for ( unsigned i = 0; i < numInputVariables; ++i )
+    {
+        unsigned variable = _preprocessedQuery.inputVariableByIndex( i );
+        inputAssignment[i] = _tableau->getLowerBound( variable );
+    }
+
+    // Evaluate the network for this assignment
+    _networkLevelReasoner->evaluate( inputAssignment, outputAssignment );
+
+    // Try to update as many variables as possible to match their assignment
+    for ( const auto &assignment : _networkLevelReasoner->getIndexToWeightedSumAssignment() )
+    {
+        unsigned variable = _networkLevelReasoner->getWeightedSumVariable( assignment.first._layer, assignment.first._neuron );
+
+        if ( !_tableau->isBasic( variable ) )
+            _tableau->setNonBasicAssignment( variable, assignment.second, false );
+    }
+
+    for ( const auto &assignment : _networkLevelReasoner->getIndexToActivationResultAssignment() )
+    {
+        unsigned variable = _networkLevelReasoner->getActivationResultVariable( assignment.first._layer, assignment.first._neuron );
+
+        if ( !_tableau->isBasic( variable ) )
+            _tableau->setNonBasicAssignment( variable, assignment.second, false );
+    }
+
+    // We did what we could for the non-basics; now let the tableau compute
+    // the basic assignment
+    _tableau->computeAssignment();
+
+    delete[] outputAssignment;
+    delete[] inputAssignment;
 }
 
 //

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -412,6 +412,13 @@ private:
     bool shouldExitDueToTimeout( unsigned timeout ) const;
 
     /*
+      Evaluate the network on legal inputs; obtain the assignment
+      for as many intermediate nodes as possible; and then try
+      to assign these values to the corresponding variables.
+    */
+    void warmStart();
+
+    /*
       Helper functions for input query preprocessing
     */
     void informConstraintsOfInitialBounds( InputQuery &inputQuery ) const;

--- a/src/engine/InputQuery.h
+++ b/src/engine/InputQuery.h
@@ -145,13 +145,6 @@ private:
     */
     void freeConstraintsIfNeeded();
 
-    /*
-      An object that knows the topology of the network being checked,
-      and can be used for various operations such as network
-      evaluation of topology-based bound tightening.
-     */
-    NetworkLevelReasoner *_networkLevelReasoner;
-
 public:
     /*
       Mapping of input/output variables to their indices.
@@ -162,6 +155,16 @@ public:
     Map<unsigned, unsigned> _variableToOutputIndex;
     Map<unsigned, unsigned> _outputIndexToVariable;
 
+    /*
+      An object that knows the topology of the network being checked,
+      and can be used for various operations such as network
+      evaluation of topology-based bound tightening.
+     */
+    NetworkLevelReasoner *_networkLevelReasoner;
+
+    /*
+      Symbolic bound tightener.
+    */
     SymbolicBoundTightener *_sbt;
 };
 

--- a/src/engine/MarabouError.h
+++ b/src/engine/MarabouError.h
@@ -44,6 +44,7 @@ public:
         SYMBOLIC_BOUND_TIGHTENER_UNKNOWN_VARIABLE_INDEX = 19,
         MERGED_INPUT_VARIABLE = 20,
         MERGED_OUTPUT_VARIABLE = 21,
+        INVALID_WEIGHTED_SUM_INDEX = 22,
 
         // Error codes for Query Loader
         FILE_DOES_NOT_EXIST = 100,

--- a/src/engine/NetworkLevelReasoner.cpp
+++ b/src/engine/NetworkLevelReasoner.cpp
@@ -13,10 +13,11 @@
 
  **/
 
-#include <cstring>
 #include "Debug.h"
+#include "MStringf.h"
 #include "NetworkLevelReasoner.h"
 #include "MarabouError.h"
+#include <cstring>
 
 NetworkLevelReasoner::NetworkLevelReasoner()
     : _weights( NULL )
@@ -118,7 +119,7 @@ void NetworkLevelReasoner::setBias( unsigned layer, unsigned neuron, double bias
     _bias[Index( layer, neuron )] = bias;
 }
 
-void NetworkLevelReasoner::evaluate( double *input, double *output ) const
+void NetworkLevelReasoner::evaluate( double *input, double *output )
 {
     memcpy( _work1, input, sizeof(double) * _layerSizes[0] );
 
@@ -139,6 +140,10 @@ void NetworkLevelReasoner::evaluate( double *input, double *output ) const
                 _work2[targetNeuron] += _work1[sourceNeuron] * weight;
             }
 
+            // Store weighted sum if needed
+            if ( _indexToWeightedSumVariable.exists( index ) )
+                _indexToWeightedSumAssignment[index] = _work2[targetNeuron];
+
             // Apply activation function
             if ( _neuronToActivationFunction.exists( index ) )
             {
@@ -154,12 +159,44 @@ void NetworkLevelReasoner::evaluate( double *input, double *output ) const
                     break;
                 }
             }
+
+            // Store activation result if needed
+            if ( _indexToActivationResultVariable.exists( index ) )
+                _indexToActivationResultAssignment[index] = _work2[targetNeuron];
         }
 
         memcpy( _work1, _work2, sizeof(double) * targetLayerSize );
     }
 
     memcpy( output, _work1, sizeof(double) * _layerSizes[_numberOfLayers - 1] );
+}
+
+void NetworkLevelReasoner::setWeightedSumVariable( unsigned layer, unsigned neuron, unsigned variable )
+{
+    _indexToWeightedSumVariable[Index( layer, neuron )] = variable;
+}
+
+unsigned NetworkLevelReasoner::getWeightedSumVariable( unsigned layer, unsigned neuron ) const
+{
+    Index index( layer, neuron );
+    if ( !_indexToWeightedSumVariable.exists( index ) )
+        throw MarabouError( MarabouError::INVALID_WEIGHTED_SUM_INDEX, Stringf( "weighted sum: <%u,%u>", layer, neuron ).ascii() );
+
+    return _indexToWeightedSumVariable[index];
+}
+
+void NetworkLevelReasoner::setActivationResultVariable( unsigned layer, unsigned neuron, unsigned variable )
+{
+    _indexToActivationResultVariable[Index( layer, neuron )] = variable;
+}
+
+unsigned NetworkLevelReasoner::getActivationResultVariable( unsigned layer, unsigned neuron ) const
+{
+    Index index( layer, neuron );
+    if ( !_indexToActivationResultVariable.exists( index ) )
+        throw MarabouError( MarabouError::INVALID_WEIGHTED_SUM_INDEX, Stringf( "activation result: <%u,%u>", layer, neuron ).ascii() );
+
+    return _indexToActivationResultVariable[index];
 }
 
 void NetworkLevelReasoner::storeIntoOther( NetworkLevelReasoner &other ) const
@@ -179,6 +216,118 @@ void NetworkLevelReasoner::storeIntoOther( NetworkLevelReasoner &other ) const
 
     for ( const auto &pair : _bias )
         other.setBias( pair.first._layer, pair.first._neuron, pair.second );
+
+    other._indexToWeightedSumVariable = _indexToWeightedSumVariable;
+    other._indexToActivationResultVariable = _indexToActivationResultVariable;
+    other._indexToWeightedSumAssignment = _indexToWeightedSumAssignment;
+    other._indexToActivationResultAssignment = _indexToActivationResultAssignment;
+}
+
+const Map<NetworkLevelReasoner::Index, unsigned> &NetworkLevelReasoner::getIndexToWeightedSumVariable()
+{
+    return _indexToWeightedSumVariable;
+}
+
+const Map<NetworkLevelReasoner::Index, unsigned> &NetworkLevelReasoner::getIndexToActivationResultVariable()
+{
+    return _indexToActivationResultVariable;
+}
+
+const Map<NetworkLevelReasoner::Index, double> &NetworkLevelReasoner::getIndexToWeightedSumAssignment()
+{
+    return _indexToWeightedSumAssignment;
+}
+
+const Map<NetworkLevelReasoner::Index, double> &NetworkLevelReasoner::getIndexToActivationResultAssignment()
+{
+    return _indexToActivationResultAssignment;
+}
+
+void NetworkLevelReasoner::updateVariableIndices( const Map<unsigned, unsigned> &oldIndexToNewIndex,
+                                                  const Map<unsigned, unsigned> &mergedVariables )
+{
+    // First, do a pass to handle any merged variables
+    auto bIt = _indexToWeightedSumVariable.begin();
+    while ( bIt != _indexToWeightedSumVariable.end() )
+    {
+        unsigned b = bIt->second;
+
+        while ( mergedVariables.exists( b ) )
+        {
+            bIt->second = mergedVariables[b];
+            b = bIt->second;
+        }
+
+        ++bIt;
+    }
+
+    auto fIt = _indexToActivationResultVariable.begin();
+    while ( fIt != _indexToActivationResultVariable.end() )
+    {
+        unsigned f = fIt->second;
+
+        while ( mergedVariables.exists( f ) )
+        {
+            fIt->second = mergedVariables[f];
+            f = fIt->second;
+        }
+
+        ++fIt;
+    }
+
+    // Now handle re-indexing
+    bIt = _indexToWeightedSumVariable.begin();
+    while ( bIt != _indexToWeightedSumVariable.end() )
+    {
+        unsigned b = bIt->second;
+
+        if ( !oldIndexToNewIndex.exists( b ) )
+        {
+            // This variable has been eliminated, remove from map
+            bIt = _indexToWeightedSumVariable.erase( bIt );
+        }
+        else
+        {
+            if ( oldIndexToNewIndex[b] == b )
+            {
+                // Index hasn't changed, skip
+            }
+            else
+            {
+                // Index has changed
+                bIt->second = oldIndexToNewIndex[b];
+            }
+
+            ++bIt;
+            continue;
+        }
+    }
+
+    fIt = _indexToActivationResultVariable.begin();
+    while ( fIt != _indexToActivationResultVariable.end() )
+    {
+        unsigned f = fIt->second;
+        if ( !oldIndexToNewIndex.exists( f ) )
+        {
+            // This variable has been eliminated, remove from map
+            fIt = _indexToActivationResultVariable.erase( fIt );
+        }
+        else
+        {
+            if ( oldIndexToNewIndex[f] == f )
+            {
+                // Index hasn't changed, skip
+            }
+            else
+            {
+                // Index has changed
+                fIt->second = oldIndexToNewIndex[f];
+            }
+
+            ++fIt;
+            continue;
+        }
+    }
 }
 
 //

--- a/src/engine/NetworkLevelReasoner.h
+++ b/src/engine/NetworkLevelReasoner.h
@@ -26,38 +26,14 @@
 class NetworkLevelReasoner
 {
 public:
-    NetworkLevelReasoner();
-    ~NetworkLevelReasoner();
-
-    /*
-      Interface methods for populating the network: settings its
-      number of layers and the layer sizes, kinds of activation
-      functions, weights and biases, etc.
-    */
-    enum ActivationFunction {
-        ReLU,
-    };
-
-    void setNumberOfLayers( unsigned numberOfLayers );
-    void setLayerSize( unsigned layer, unsigned size );
-    void allocateWeightMatrices();
-    void setNeuronActivationFunction( unsigned layer, unsigned neuron, ActivationFunction activationFuction );
-    void setWeight( unsigned sourceLayer, unsigned sourceNeuron, unsigned targetNeuron, double weight );
-    void setBias( unsigned layer, unsigned neuron, double bias );
-
-    /*
-      Interface methods for performing operations on the network.
-    */
-    void evaluate( double *input, double *output ) const;
-
-    /*
-      Duplicate the reasoner
-    */
-    void storeIntoOther( NetworkLevelReasoner &other ) const;
-
-private:
     struct Index
     {
+        Index()
+            : _layer( 0 )
+            , _neuron( 0 )
+        {
+        }
+
         Index( unsigned layer, unsigned neuron )
             : _layer( layer )
             , _neuron( neuron )
@@ -78,6 +54,61 @@ private:
         unsigned _neuron;
     };
 
+    NetworkLevelReasoner();
+    ~NetworkLevelReasoner();
+
+    /*
+      Interface methods for populating the network: settings its
+      number of layers and the layer sizes, kinds of activation
+      functions, weights and biases, etc.
+    */
+    enum ActivationFunction {
+        ReLU,
+    };
+
+    void setNumberOfLayers( unsigned numberOfLayers );
+    void setLayerSize( unsigned layer, unsigned size );
+    void allocateWeightMatrices();
+    void setNeuronActivationFunction( unsigned layer, unsigned neuron, ActivationFunction activationFuction );
+    void setWeight( unsigned sourceLayer, unsigned sourceNeuron, unsigned targetNeuron, double weight );
+    void setBias( unsigned layer, unsigned neuron, double bias );
+
+    /*
+      Mapping from node indices to the variables representing their
+      weighted sum values and activation result values.
+    */
+    void setWeightedSumVariable( unsigned layer, unsigned neuron, unsigned variable );
+    unsigned getWeightedSumVariable( unsigned layer, unsigned neuron ) const;
+    void setActivationResultVariable( unsigned layer, unsigned neuron, unsigned variable );
+    unsigned getActivationResultVariable( unsigned layer, unsigned neuron ) const;
+    const Map<Index, unsigned> &getIndexToWeightedSumVariable();
+    const Map<Index, unsigned> &getIndexToActivationResultVariable();
+
+    /*
+      Mapping from node indices to the nodes' assignments, as computed
+      by evaluate()
+    */
+    const Map<Index, double> &getIndexToWeightedSumAssignment();
+    const Map<Index, double> &getIndexToActivationResultAssignment();
+
+    /*
+      Interface methods for performing operations on the network.
+    */
+    void evaluate( double *input, double *output );
+
+    /*
+      Duplicate the reasoner
+    */
+    void storeIntoOther( NetworkLevelReasoner &other ) const;
+
+    /*
+      Methods that are typically invoked by the preprocessor,
+      to inform us of changes in variable indices
+    */
+    void updateVariableIndices( const Map<unsigned, unsigned> &oldIndexToNewIndex,
+                                const Map<unsigned, unsigned> &mergedVariables );
+
+private:
     unsigned _numberOfLayers;
     Map<unsigned, unsigned> _layerSizes;
     Map<Index, ActivationFunction> _neuronToActivationFunction;
@@ -90,6 +121,18 @@ private:
     double *_work2;
 
     void freeMemoryIfNeeded();
+
+    /*
+      Mappings of indices to weighted sum and activation result variables
+    */
+    Map<Index, unsigned> _indexToWeightedSumVariable;
+    Map<Index, unsigned> _indexToActivationResultVariable;
+
+    /*
+      Store the assignment to all variables when evaluate() is called
+    */
+    Map<Index, double> _indexToWeightedSumAssignment;
+    Map<Index, double> _indexToActivationResultAssignment;
 };
 
 #endif // __NetworkLevelReasoner_h__

--- a/src/engine/Preprocessor.cpp
+++ b/src/engine/Preprocessor.cpp
@@ -481,7 +481,6 @@ void Preprocessor::eliminateVariables()
     if ( _statistics )
         _statistics->ppSetNumEliminatedVars( _fixedVariables.size() + _mergedVariables.size() );
 
-
     // Check and remove any fixed variables from the debugging solution
     for ( unsigned i = 0; i < _preprocessed.getNumberOfVariables(); ++i )
     {
@@ -633,6 +632,10 @@ void Preprocessor::eliminateVariables()
     // Let the SBT know of changes in indices and merged variables
     if ( _preprocessed._sbt )
         _preprocessed._sbt->updateVariableIndices( _oldIndexToNewIndex, _mergedVariables, _fixedVariables );
+
+    // Let the NLR know of changes in indices and merged variables
+    if ( _preprocessed._networkLevelReasoner )
+        _preprocessed._networkLevelReasoner->updateVariableIndices( _oldIndexToNewIndex, _mergedVariables );
 
     // Update the lower/upper bound maps
     for ( unsigned i = 0; i < _preprocessed.getNumberOfVariables(); ++i )

--- a/src/input_parsers/AcasParser.cpp
+++ b/src/input_parsers/AcasParser.cpp
@@ -202,6 +202,20 @@ void AcasParser::generateQuery( InputQuery &inputQuery )
         }
     }
 
+    // Variable indexing
+    for ( unsigned i = 1; i < numberOfLayers - 1; ++i )
+    {
+        unsigned layerSize = _acasNeuralNetwork.getLayerSize( i );
+
+        for ( unsigned j = 0; j < layerSize; ++j )
+        {
+            unsigned b = _nodeToB[NodeIndex( i, j )];
+            unsigned f = _nodeToF[NodeIndex( i, j )];
+            nlr->setWeightedSumVariable( i, j, b );
+            nlr->setActivationResultVariable( i, j, f );
+        }
+    }
+
     // Store the reasoner in the input query
     inputQuery.setNetworkLevelReasoner( nlr );
 
@@ -254,7 +268,7 @@ void AcasParser::generateQuery( InputQuery &inputQuery )
                 unsigned b = _nodeToB[NodeIndex( i, j )];
                 sbt->setReluBVariable( i, j, b );
 
-                unsigned f = _nodeToF[NodeIndex(i, j)];
+                unsigned f = _nodeToF[NodeIndex( i, j )];
                 sbt->setReluFVariable( i, j, f );
             }
         }
@@ -264,7 +278,7 @@ void AcasParser::generateQuery( InputQuery &inputQuery )
             sbt->setReluFVariable( numberOfLayers - 1, i, _nodeToB[NodeIndex( numberOfLayers - 1, i )] );
         }
 
-        inputQuery.setSymbolicBoundTightener(sbt);
+        inputQuery.setSymbolicBoundTightener( sbt );
     }
 }
 

--- a/src/input_parsers/InputParserError.h
+++ b/src/input_parsers/InputParserError.h
@@ -26,6 +26,7 @@ public:
         UNEXPECTED_INPUT = 1,
         FILE_DOESNT_EXIST = 2,
         UNSUPPORTED_BOUND_TYPE = 3,
+        NETWORK_LEVEL_REASONING_DISABLED = 4,
     };
 
     InputParserError( InputParserError::Code code ) : Error( "InputParserError", (int)code )

--- a/src/input_parsers/PropertyParser.cpp
+++ b/src/input_parsers/PropertyParser.cpp
@@ -87,31 +87,66 @@ void PropertyParser::processSingleLine( const String &line, InputQuery &inputQue
 
         bool inputVariable = token.contains( "x" );
         bool outputVariable = token.contains( "y" );
+        bool weightedSumVariable = token.contains( "ws" );
 
-        if ( !( inputVariable xor outputVariable ) )
+        // Make sure that we have identified precisely one kind of variable
+        unsigned variableKindSanity = 0;
+        if ( inputVariable ) ++variableKindSanity;
+        if ( outputVariable ) ++variableKindSanity;
+        if ( weightedSumVariable ) ++variableKindSanity;
+
+        if ( variableKindSanity != 1 )
             throw InputParserError( InputParserError::UNEXPECTED_INPUT, token.ascii() );
 
+        // Determine the index (in input query terms) of the variable whose
+        // bound is being set.
+
+        unsigned variable = 0;
         List<String> subTokens;
-        if ( inputVariable )
-            subTokens = token.tokenize( "x" );
-        else
-            subTokens = token.tokenize( "y" );
-
-        if ( subTokens.size() != 1 )
-            throw InputParserError( InputParserError::UNEXPECTED_INPUT, token.ascii() );
-
-        unsigned justIndex = atoi( subTokens.rbegin()->ascii() );
-        unsigned variable;
 
         if ( inputVariable )
         {
+            subTokens = token.tokenize( "x" );
+
+            if ( subTokens.size() != 1 )
+                throw InputParserError( InputParserError::UNEXPECTED_INPUT, token.ascii() );
+
+            unsigned justIndex = atoi( subTokens.rbegin()->ascii() );
+
             ASSERT( justIndex < inputQuery.getNumInputVariables() );
             variable = inputQuery.inputVariableByIndex( justIndex );
         }
-        else
+        else if ( outputVariable )
         {
+            subTokens = token.tokenize( "y" );
+
+            if ( subTokens.size() != 1 )
+                throw InputParserError( InputParserError::UNEXPECTED_INPUT, token.ascii() );
+
+            unsigned justIndex = atoi( subTokens.rbegin()->ascii() );
+
             ASSERT( justIndex < inputQuery.getNumOutputVariables() );
             variable = inputQuery.outputVariableByIndex( justIndex );
+        }
+        else if ( weightedSumVariable )
+        {
+            // These variables are of the form ws_2_5
+            subTokens = token.tokenize( "_" );
+
+            if ( subTokens.size() != 3 )
+                throw InputParserError( InputParserError::UNEXPECTED_INPUT, token.ascii() );
+
+            auto subToken = subTokens.begin();
+            ++subToken;
+            unsigned layerIndex = atoi( subToken->ascii() );
+            ++subToken;
+            unsigned nodeIndex = atoi( subToken->ascii() );
+
+            NetworkLevelReasoner *nlr = inputQuery.getNetworkLevelReasoner();
+            if ( !nlr )
+                throw InputParserError( InputParserError::NETWORK_LEVEL_REASONING_DISABLED );
+
+            variable = nlr->getWeightedSumVariable( layerIndex, nodeIndex );
         }
 
         if ( type == Equation::GE )


### PR DESCRIPTION
* property files can address hidden nodes

* store also f vars, not just b vars

* have NLR store the intermediate values as it evalutes an assignment

* bug fixes, cleanup

* inform the NLR about index changes as part of preprocessing

* warm start flags

* disable by default

* cleanup